### PR TITLE
Allow Portico gateway users to submit the `AutoSubstantiation` and `FirstAdditionalAmtInfo` elements for Flex card support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ except ApiException as e:
     // handle errors
 ```
 
+#### Process a Payment with Healthcare Amount Example
+
+This passes on to the issuing bank what part of the total payment amount was used for a healthcare purchase. This allows the use of FSA (Flex) cards. This is currently only supported with users of the Portico Gateway. 
+
+```python
+card = CreditCardData()
+card.number = '4111111111111111'
+card.exp_month = '12'
+card.exp_year = '2025'
+card.cvn = '123'
+card.card_holder_name = 'Joe Smith'
+
+try:
+    response = card.charge(129.99) \
+        .with_currency("EUR") \
+        .with_healthcare_amount(100.00)
+        .execute()
+
+    result = response.response_code # 00 == Success
+    message = response.response_message # [ test system ] AUTHORISED
+
+except ApiException as e:
+    // handle errors
+```
+
+
 #### Test Card Data
 
 Name        | Number           | Exp Month | Exp Year | CVN

--- a/globalpayments/api/builders/__init__.py
+++ b/globalpayments/api/builders/__init__.py
@@ -104,6 +104,7 @@ class AuthorizationBuilder(TransactionBuilder):
     schedule_id = None
     shipping_address = None
     timestamp = None
+    healthcare = None
 
     def with_address(self, address, address_type=AddressType.Billing):
         if not isinstance(address, Address):
@@ -118,6 +119,10 @@ class AuthorizationBuilder(TransactionBuilder):
     def with_alias(self, action, value):
         self.alias = value
         self.alias_action = action
+        return self
+    
+    def with_healthcare_amount(self, value):
+        self.healthcare = value
         return self
 
     def with_cash_back(self, value):

--- a/globalpayments/api/gateways/__init__.py
+++ b/globalpayments/api/gateways/__init__.py
@@ -623,6 +623,12 @@ class PorticoConnector(XmlGateway):
                     et.SubElement(block1, 'AllowPartialAuth').text = \
                         'Y' if builder.allow_partial_auth else 'N'
 
+        if builder.healthcare is not None:
+            auto_substantiation = et.SubElement(block1, 'AutoSubstantiation')
+            first_addl_amt_info = et.SubElement(auto_substantiation, 'FirstAdditionalAmtInfo')
+            et.SubElement(first_addl_amt_info, 'AmtType').text = 'TOTAL_HEALTHCARE_AMT'
+            et.SubElement(first_addl_amt_info, 'Amt').text = builder.healthcare
+            
         if builder.amount is not None:
             et.SubElement(block1, 'Amt').text = str(builder.amount)
 


### PR DESCRIPTION
This updates the Portico gateway builder to allow these XML elements for FSA transactions.